### PR TITLE
feat(socket): add granular update filters for user presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules
 
 # package-lock.json
 package-lock.json
+
+# .vscode
+.vscode


### PR DESCRIPTION
- .gitignore:
  - ignore .vscode directory
- README.md:
  - document new update type filters for subscriptions
  - add examples for subscribing to specific update types
  - clarify WebSocket API behavior and payloads
- index.js:
  - support subscribing to user updates with specific update type filters
    - validate and store update type preferences per client
    - emit filtered updates only to relevant subscribers
    - add updateType field in userUpdate events
    - debounce and batch update notifications by type
  - detect granular changes in user presence, activity, avatar, username, custom status, and display name
    - emit updates only for changed types
  - add '/' endpoint giving API metadata and supported endpoints